### PR TITLE
Allow assert in helper functions

### DIFF
--- a/example/foo.py
+++ b/example/foo.py
@@ -2,3 +2,7 @@ import re
 
 def find_words(text: str) -> list:
     return re.findall(r"\w+", text)
+
+
+def add1(x: int) -> int:
+    return x + 1

--- a/example/tests/test_add1/test_1.yml
+++ b/example/tests/test_add1/test_1.yml
@@ -1,0 +1,2 @@
+input: 1
+output: 2

--- a/example/tests/test_foo.py
+++ b/example/tests/test_foo.py
@@ -1,6 +1,15 @@
 import pytest
-from foo import find_words
+from foo import find_words, add1
 
 @pytest.mark.golden_test("test_find_words/*.yml")
 def test_find_words(golden):
     assert find_words(golden["input"]) == golden.out["output"]
+
+
+@pytest.mark.golden_test("test_add1/*.yml")
+def test_add1(golden):
+    helper(add1(golden["input"]), golden.out["output"])
+
+
+def helper(x, y):
+    assert x == y

--- a/pytest_golden/plugin.py
+++ b/pytest_golden/plugin.py
@@ -8,9 +8,9 @@ import pathlib
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Collection, Sequence, TypeVar
 
+import _pytest
 import atomicwrites
 import pytest
-import _pytest
 
 from . import yaml
 

--- a/tests/full/test_assert_in_helper_function.yml
+++ b/tests/full/test_assert_in_helper_function.yml
@@ -1,0 +1,13 @@
+test: |
+  def helper(x, y):
+    assert x == y
+  def test_assert_in_helper_function(golden):
+    golden = golden.open("gold.yml")
+    helper(5, golden.out["output"])
+files:
+  gold.yml: |
+    output: 5
+outcomes:
+  passed: 1
+outcomes_update:
+  passed: 1


### PR DESCRIPTION
This makes it possible to use `assert`s in helper functions (called from the test functions). E.g.

```py
@pytest.mark.golden_test("test_add1/*.yml")
def test_add1(golden):
    helper(add1(golden["input"]), golden.out["output"])

def helper(x, y):
    assert x == y
```

This is useful if you have individual checks of a more complicated test case that you want to check between test functions.

Previously this was not possible because the stack frames were explicitly filtered to the one from the test function and two internal functions of this library.

Instead of an allow list I added a deny list to skip over functions calls that exist because pytest has rewritten the assertion. I'm not sure how stable this part it because we need to use the private `_pytest`. It will probably break if pytest changes something here. But I didn't find another way to get to that function.

I would appreciate more testing of this PR. I have only tested in my local project and the examples and tests in this repo.