### PR TITLE
Allow user to create golen files automatically

### DIFF
--- a/pytest_golden/plugin.py
+++ b/pytest_golden/plugin.py
@@ -30,6 +30,12 @@ def pytest_addoption(parser):
         default=False,
         help="reset golden master benchmarks",
     )
+    parser.addoption(
+        "--create-goldens",
+        action="store_true",
+        default=False,
+        help="create golden master benchmarks",
+    )
 
 
 @pytest.fixture
@@ -43,7 +49,9 @@ def golden(request):
     fixt = GoldenTestFixtureFactory(
         pathlib.Path(request.module.__file__),
         func,
-        request.config.getoption("--update-goldens"),
+        request.config.getoption("--create-goldens")
+        or request.config.getoption("--update-goldens"),
+        request.config.getoption("--create-goldens"),
         request.config.getini("enable_assertion_pass_hook"),
     )
     if path is not None:
@@ -84,6 +92,7 @@ class GoldenTestFixtureFactory:
     path: pathlib.Path
     func: Callable
     update_goldens: bool
+    create_goldens: bool
     assertions_enabled: bool
 
     _fixtures: list[GoldenTestFixture] = dataclasses.field(init=False)
@@ -96,6 +105,7 @@ class GoldenTestFixtureFactory:
             path=self.path.parent / path,
             func=self.func,
             update_goldens=self.update_goldens,
+            create_goldens=self.create_goldens,
             assertions_enabled=self.assertions_enabled,
         )
         self._fixtures.append(fixt)
@@ -118,9 +128,13 @@ class GoldenTestFixture(GoldenTestFixtureFactory):
 
     def __post_init__(self):
         self._used_fields = set()
+        mode = "r"
 
         # Keep inputs as a separate copy, so if an input gets mutated, it isn't written back.
-        with open(self.path, encoding="utf-8") as f:
+        if self.create_goldens and not self.path.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            mode = "w+"
+        with open(self.path, mode, encoding="utf-8") as f:
             self._inputs = yaml._safe.load(f) or {}
         if not isinstance(self._inputs, dict):
             raise UsageError(f"The YAML file '{self.path}' must contain a dict at the top level.")


### PR DESCRIPTION
If user may want to maintain golder resuls for various configurations, for example:
```
platform_name = platform.release()
golden.open(f"{platform_name}/{request.node.name}.yml")
```
Collecting data for new platforms become complicated because each file should be created manually. Let's add  --create-golen option which create golden files automatically. create-golden options is automatically enable update-golden, otherwise it does not make sense.