### PR TITLE
feat: add golden_root pytest ini option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Whenever the function under test gets changed, its result may change as well, an
 
 **See [detailed usage](#usage).**
 
+### `golden_root` (pytest ini)
+
+Set in `pytest.ini` or `pyproject.toml` under `[tool.pytest.ini_options]`:
+
+```toml
+golden_root = "goldens"
+```
+
+When set, relative paths passed to `golden.open(...)` resolve from this directory (relative to the pytest rootdir) instead of the test module's directory. When unset, behavior is unchanged (golden files live next to the test module, as in the examples above).
+
+Development gates for this repository: `hatch run style:check` and `hatch run test:pytest`.
+
 ## The case for golden testing
 
 Consider this normal situation when testing a function (e.g. a function to list all words in a sentence).

--- a/pytest_golden/paths.py
+++ b/pytest_golden/paths.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-import os
 import pathlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import os
 
 
 def golden_base_directory(
@@ -19,4 +22,4 @@ def golden_base_directory(
 
 
 def resolve_golden_file(base: pathlib.Path, relative: os.PathLike[str]) -> pathlib.Path:
-    return base / relative
+    return (base / relative).resolve()

--- a/pytest_golden/paths.py
+++ b/pytest_golden/paths.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def golden_base_directory(
+    module_file: pathlib.Path,
+    golden_root: str,
+    rootpath: pathlib.Path,
+) -> pathlib.Path:
+    """Directory used to resolve relative golden YAML paths."""
+    if golden_root:
+        root = pathlib.Path(golden_root)
+        if not root.is_absolute():
+            root = rootpath / root
+        return root.resolve()
+    return module_file.parent.resolve()
+
+
+def resolve_golden_file(base: pathlib.Path, relative: os.PathLike[str]) -> pathlib.Path:
+    return base / relative

--- a/pytest_golden/plugin.py
+++ b/pytest_golden/plugin.py
@@ -14,7 +14,7 @@ from typing import IO, TYPE_CHECKING, Any, Callable, TypeVar
 
 import pytest
 
-from . import yaml
+from . import paths, yaml
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -88,11 +88,18 @@ def golden(request):
     except AttributeError:
         func = request.function
 
+    module_file = pathlib.Path(request.module.__file__)
+    golden_base = paths.golden_base_directory(
+        module_file,
+        request.config.getini("golden_root"),
+        request.config.rootpath,
+    )
     fixt = GoldenTestFixtureFactory(
-        pathlib.Path(request.module.__file__),
+        module_file,
         func,
         request.config.getoption("--update-goldens"),
         request.config.getini("enable_assertion_pass_hook"),
+        golden_base=golden_base,
     )
     if path is not None:
         fixt = fixt.open(path)
@@ -133,6 +140,7 @@ class GoldenTestFixtureFactory:
     func: Callable
     update_goldens: bool
     assertions_enabled: bool
+    golden_base: pathlib.Path
 
     _fixtures: list[GoldenTestFixture] = dataclasses.field(init=False)
 
@@ -141,7 +149,7 @@ class GoldenTestFixtureFactory:
 
     def open(self, path: os.PathLike) -> GoldenTestFixture:
         fixt = GoldenTestFixture(
-            path=self.path.parent / path,
+            path=paths.resolve_golden_file(self.golden_base, path),
             func=self.func,
             update_goldens=self.update_goldens,
             assertions_enabled=self.assertions_enabled,
@@ -400,7 +408,11 @@ def pytest_generate_tests(metafunc) -> None:
         warn(f"Useless '{MARKER_NAME}' marker on a test without a '{FIXTURE_NAME}' fixture")
         return
 
-    directory = pathlib.Path(metafunc.module.__file__).parent
+    directory = paths.golden_base_directory(
+        pathlib.Path(metafunc.module.__file__),
+        metafunc.config.getini("golden_root"),
+        metafunc.config.rootpath,
+    )
     paths: Collection[pathlib.Path] = dict.fromkeys(
         path for pattern in patterns for path in directory.glob(pattern)
     )

--- a/pytest_golden/plugin.py
+++ b/pytest_golden/plugin.py
@@ -153,6 +153,7 @@ class GoldenTestFixtureFactory:
             func=self.func,
             update_goldens=self.update_goldens,
             assertions_enabled=self.assertions_enabled,
+            golden_base=self.golden_base,
         )
         self._fixtures.append(fixt)
         return fixt
@@ -413,15 +414,15 @@ def pytest_generate_tests(metafunc) -> None:
         metafunc.config.getini("golden_root"),
         metafunc.config.rootpath,
     )
-    paths: Collection[pathlib.Path] = dict.fromkeys(
+    golden_paths: Collection[pathlib.Path] = dict.fromkeys(
         path for pattern in patterns for path in directory.glob(pattern)
     )
-    if not paths:
+    if not golden_paths:
         warn(f"The patterns {patterns!r} didn't match anything")
         return
 
     # `::test_foo[foo/*.yaml]` -> `::test_foo[*.yaml]`
-    rel_paths = [path.relative_to(directory) for path in paths]
+    rel_paths = [path.relative_to(directory) for path in golden_paths]
     skip_parts = None
     if all(
         path.parts[0].removeprefix("test_") == item.originalname.removeprefix("test_")
@@ -432,7 +433,7 @@ def pytest_generate_tests(metafunc) -> None:
 
     metafunc.parametrize(
         FIXTURE_NAME,
-        ((path, metafunc.function) for path in paths),
+        ((path, metafunc.function) for path in golden_paths),
         ids=ids,
         indirect=True,
     )

--- a/pytest_golden/plugin.py
+++ b/pytest_golden/plugin.py
@@ -73,6 +73,11 @@ def pytest_addoption(parser):
         default=False,
         help="reset golden master benchmarks",
     )
+    parser.addini(
+        "golden_root",
+        default="",
+        help="Base directory for resolving golden YAML paths (relative to pytest rootdir)",
+    )
 
 
 @pytest.fixture

--- a/tests/full/test_golden_root.yml
+++ b/tests/full/test_golden_root.yml
@@ -11,3 +11,5 @@ files:
     value: 99
 outcomes:
   passed: 1
+outcomes_update:
+  passed: 1

--- a/tests/full/test_golden_root.yml
+++ b/tests/full/test_golden_root.yml
@@ -1,0 +1,13 @@
+test: |
+  def test_golden_root(golden):
+    g = golden.open("case.yml")
+    assert g["value"] == 99
+ini: |
+  [pytest]
+  enable_assertion_pass_hook=true
+  golden_root = goldens
+files:
+  goldens/case.yml: |
+    value: 99
+outcomes:
+  passed: 1

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,7 +16,10 @@ def test_full(testdir, golden, upd):
 
     files = golden.get("files") or {}
     for name, content in files.items():
-        (testdir.tmpdir / name).write_text(content, encoding="utf-8")
+        path = testdir.tmpdir.join(name)
+        if "/" in name or "\\" in name:
+            path.dirpath().ensure(dir=1)
+        path.write(content)
 
     with pytest.warns(plugin.GoldenTestUsageWarning) as record:
         warnings.warn("OK", plugin.GoldenTestUsageWarning)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,7 +10,8 @@ from pytest_golden import plugin
 def test_full(testdir, golden, upd):
     assert golden.path.stem in golden["test"]
 
-    testdir.makefile(".ini", pytest="[pytest]\nenable_assertion_pass_hook=true\n")
+    ini = golden.get("ini") or "[pytest]\nenable_assertion_pass_hook=true\n"
+    testdir.makefile(".ini", pytest=ini)
     testdir.makepyfile(golden["test"])
 
     files = golden.get("files") or {}


### PR DESCRIPTION
## Summary

Add optional `golden_root` pytest ini setting so golden YAML paths can resolve from a project subdirectory (monorepo / alternate layout) instead of only beside the test module.

- New `pytest_golden/paths.py` for base-directory resolution
- `golden_root` registered via `pytest_addoption` / `getini`
- Regression test `tests/full/test_golden_root.yml`
- README section documenting the option

**Default behavior unchanged** when `golden_root` is unset.

## Motivation

Users with goldens centralized under e.g. `goldens/` or a package data dir need a config hook without duplicating test module layout.

## Test plan

- [x] `hatch run style:check`
- [x] `hatch run test:pytest` (24 passed)
- [x] New `test_golden_root.yml` exercises ini override

## Risk

Low — additive ini option; existing tests unchanged at default.

## Experiment note

Developed under Freehold harness Experiment 6 (integration slice). Commits may be squashed on merge.
